### PR TITLE
Fix Clerk webhook raw body parsing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -13,6 +13,8 @@ console.log(
 );
 console.log("------------------------------------");
 const app = express();
+// Use raw body for Clerk webhooks before JSON parsing
+app.use('/api/webhooks/clerk', express.raw({ type: 'application/json' }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -42,7 +42,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use(ClerkExpressWithAuth());
 
   // Webhook handler for Clerk
-  app.post('/api/webhooks/clerk', express.raw({ type: 'application/json' }), async (req, res) => {
+  app.post('/api/webhooks/clerk', async (req, res) => {
     const WEBHOOK_SECRET = process.env.CLERK_WEBHOOK_SECRET;
     if (!WEBHOOK_SECRET) {
       throw new Error("Please add CLERK_WEBHOOK_SECRET from Clerk Dashboard to .env or .env.local");
@@ -57,6 +57,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
 
     const payload = req.body;
+    console.log('Clerk webhook payload is buffer:', Buffer.isBuffer(payload));
     const wh = new Webhook(WEBHOOK_SECRET);
 
     let evt;


### PR DESCRIPTION
## Summary
- mount express.raw for Clerk webhook before global JSON middleware
- ensure the webhook handler logs whether the payload is a Buffer

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687006cb98c8832d8a6f01274e83f854