### PR TITLE
fix Clerk webhook body parsing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -13,6 +13,8 @@ console.log(
 );
 console.log("------------------------------------");
 const app = express();
+// Parse Clerk webhooks as raw buffers so signature verification succeeds
+app.use('/api/webhooks/clerk', express.raw({ type: 'application/json' }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 


### PR DESCRIPTION
## Summary
- mount `express.raw` middleware for Clerk webhook at app level
- remove duplicate raw parsing from route and warn if body is not a Buffer

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_687006c3cf20832d93584897495e9a57