### PR TITLE
Validate amount for payment intent

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -659,8 +659,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/create-payment-intent", async (req, res) => {
     try {
       const { amount } = req.body;
+      const parsedAmount = Number(amount);
+      if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+        return res.status(400).json({ message: "Invalid amount" });
+      }
+
       const paymentIntent = await stripe.paymentIntents.create({
-        amount: Math.round(amount * 100), // Convert to cents
+        amount: Math.round(parsedAmount * 100), // Convert to cents
         currency: "usd",
         metadata: {
           userId: (req as RequestWithAuth).auth.userId || 'unknown',


### PR DESCRIPTION
## Summary
- check that payment amount is a finite positive number before creating a Stripe payment intent

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687006d68430832d8a40ae28d1e79905